### PR TITLE
Altered exterm appropriately

### DIFF
--- a/yaml/model/miroc3_2_medres.yaml
+++ b/yaml/model/miroc3_2_medres.yaml
@@ -12,4 +12,4 @@ contributors :
         - /organization/national-institute-environmental-studies-japan
         - /organization/frontier-research-center-global-change
 exterms :
-    /cmip3/model/MIROC3.2 (medres)
+    /cmip3/model/MIROC3.2(medres)


### PR DESCRIPTION
Per the pages at:

http://www-pcmdi.llnl.gov/ipcc/model_documentation/MIROC3.2_medres.htm

and:
http://www-pcmdi.llnl.gov/ipcc/model_documentation/ipcc_model_documentation.php

The exterm should lack a space after "3.2."
