### PR TITLE
Created ingv-sxg.yaml

### DIFF
--- a/yaml/model/ingv-sxg.yaml
+++ b/yaml/model/ingv-sxg.yaml
@@ -17,4 +17,4 @@ contributors :
     contributor :
          - /organization/instituto-nazionale-geofisica-vulcanologia
 exterms :
-    - /cmip3/model/ingv-sxg
+    - /cmip3/model/INGV-SXG


### PR DESCRIPTION
Note: I haven't found any documentation referring to this model in the way spelled out above next to "name."  It's always INGV-SXG.  See official model documentation at:
http://www.cmcc.it/wp-content/uploads/2012/08/rp0015-ans-02-2007-1.pdf

INGV = Istituto Nazionale di Geofisica e Vulcanologia
SXG = SINTEX-G
SINTEX = "Scale Interactions Experiment" (text below comes from  pp. 3019, lefthand column, 1st not-full paragraph of doc. at:
http://journals.ametsoc.org/doi/pdf/10.1175/JCLI4164.1 
   "Using the Scale Interactions Experiment (SINTEX) CGCM, Gualdi et al. (2003)
suggested that a particular IOD event in the model does not reach peak strength owing to the presence of strong ISD activity in the Indian Ocean"
